### PR TITLE
feat: grant cognito lambda execution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global Owners
+* @emogi/operations

--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,17 @@ resource "aws_cognito_user_pool" "pool" {
   tags = var.tags
 }
 
+# Grant Cognito the ability to execute each lambda function.
+resource "aws_lambda_permission" "cognito" {
+  for_each = var.enabled ? toset(local.distinct_lambda_function_names) : toset([])
+
+  statement_id  = "AllowCognitoLambdaExecution"
+  action        = "lambda:InvokeFunction"
+  function_name = each.key
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn = aws_cognito_user_pool.pool[0].arn
+}
+
 locals {
   # username_configuration
   # If no username_configuration is provided return a empty list
@@ -311,4 +322,10 @@ locals {
 
   software_token_mfa_configuration = (length(var.sms_configuration) == 0 || local.sms_configuration == null) && var.mfa_configuration == "OFF" ? [] : [local.software_token_mfa_configuration_default]
 
+  # lambda_config
+  # Generate a list of distinct lambda function names. The function name is currently the last field of the lambda ARN.
+  # https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html
+  # E.g. arn:aws:lambda:us-west-2:123456789012:function:my-function
+  # E.g. arn:aws:lambda:us-west-2:123456789012:function:my-function:1
+  distinct_lambda_function_names = distinct([for name, arn in var.lambda_config : contains(["custom_email_sender", "custom_sms_sender"], name) ? reverse(split(":", arn.lambda_arn))[0] : reverse(split(":", arn))[0]])
 }


### PR DESCRIPTION
Grant cognito lambda execution permission for each defined trigger. This is to work around a known bug in the AWS provider.
hashicorp/terraform-provider-aws#8373